### PR TITLE
support proto parser from https://github.com/coder3101/tree-sitter-proto

### DIFF
--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -344,6 +344,9 @@
     "properties": {
         "repo": "https://github.com/tree-sitter-grammars/tree-sitter-properties"
     },
+    "proto": {
+        "repo": "https://github.com/coder3101/tree-sitter-proto"
+    },
     "psv": {
         "repo": "https://github.com/amaanq/tree-sitter-csv",
         "branch": "master",

--- a/tree_sitter_language_pack/__init__.py
+++ b/tree_sitter_language_pack/__init__.py
@@ -121,6 +121,7 @@ SupportedLanguage = Union[
         "printf",
         "prisma",
         "properties",
+        "proto",
         "psv",
         "puppet",
         "purescript",


### PR DESCRIPTION
`➜ pdm run test

Set env var PDM_IGNORE_ACTIVE_VENV to ignore it.
================================================================================================================ test session starts ================================================================================================================
platform darwin -- Python 3.12.2, pytest-8.3.1, pluggy-1.5.0
rootdir: ~/tree-sitter-language-pack
configfile: pyproject.toml
plugins: anyio-4.4.0
collected 474 items

tests/entry_point_test.py ................................................................................................................................................................................................................... [ 44%]
............................................................................................................................................................................................................................................. [ 94%]
..........................                                                                                                                                                                                                                    [100%]

=============================================================================================================== 474 passed in 41.03s ================================================================================================================
`