### PR TITLE
fix: Windows compatibility and encoding issues for non-English locales

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,8 +10,12 @@ on:
 
 jobs:
   clone_vendors:
-    name: Clone vendors
-    runs-on: ubuntu-latest
+    name: Clone vendors (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -35,20 +39,25 @@ jobs:
     - name: Install Dependencies
       run: uv sync --no-install-project
 
+    - name: Create parsers directory
+      run: mkdir -p parsers
+
     - name: Clone vendors
-      run: |
-        mkdir parsers
-        uv run --no-sync scripts/clone_vendors.py
+      run: uv run --no-sync scripts/clone_vendors.py
 
     - name: Upload Parsers
       uses: actions/upload-artifact@v4
       with:
-        name: language-parsers
+        name: language-parsers-${{ matrix.os }}
         path: parsers
 
   validate:
     needs: clone_vendors
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -56,7 +65,7 @@ jobs:
     - name: Download parsers
       uses: actions/download-artifact@v4
       with:
-        name: language-parsers
+        name: language-parsers-${{ matrix.os }}
         path: parsers
 
     - name: Install uv
@@ -83,7 +92,11 @@ jobs:
       run: uv run --no-sync pre-commit run --show-diff-on-failure --color=always --all-files
   test:
     needs: clone_vendors
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -91,7 +104,7 @@ jobs:
     - name: Download parsers
       uses: actions/download-artifact@v4
       with:
-        name: language-parsers
+        name: language-parsers-${{ matrix.os }}
         path: parsers
 
     - name: Install uv
@@ -119,6 +132,7 @@ jobs:
       run: uv run --no-sync setup.py build_ext --inplace
 
     - name: Test
+      shell: bash
       run: uv run --no-sync pytest tests -v
       env:
         PROJECT_ROOT: ${{github.workspace}}

--- a/scripts/clone_vendors.py
+++ b/scripts/clone_vendors.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-import platform
 import os
+import platform
 import re
 import subprocess
 from functools import partial
@@ -82,20 +82,15 @@ async def handle_generate(language_name: str, directory: str | None, abi_version
         if directory
         else (vendor_directory / language_name).resolve()
     )
-    
-    # 윈도우 환경에서는 cmd.exe /c를 통해 명령어를 실행해야 PATH에서 tree-sitter를 찾을 수 있음
+
     if platform.system() == "Windows":
         cmd = ["cmd", "/c", "tree-sitter", "generate", "--abi", str(abi_version)]
         shell = False
     else:
         cmd = ["tree-sitter", "generate", "--abi", str(abi_version)]
         shell = False
-        
-    await run_sync(
-        partial(
-            subprocess.run, cmd, cwd=str(target_dir), check=False, shell=shell
-        )
-    )
+
+    await run_sync(partial(subprocess.run, cmd, cwd=str(target_dir), check=False, shell=shell))
     print(f"Generated {language_name} parser successfully")
 
 
@@ -131,12 +126,12 @@ async def move_src_folder(language_name: str, directory: str | None) -> None:
             # replace any include statement that points at common with an updated path:
             # e.g. '#include "../../common/scanner.h"' should point at (target_common_dir / 'scanner.h').relative_path()
             file_contents = await AsyncPath(file).read_text()
-            
+
             # Create a properly formatted replacement path with the correct path separator
-            replacement_path = str((target_source_dir / "common").relative_to(file.parent, walk_up=True))
+            replacement_path = os.path.relpath(target_source_dir / "common", file.parent)
             # Ensure forward slashes in replacement path for C includes (even on Windows)
-            replacement_path = replacement_path.replace('\\', '/') + '/'
-            
+            replacement_path = replacement_path.replace("\\", "/") + "/"
+
             file_contents = COMMON_RE_PATTERN.sub(replacement_path, file_contents)
             await AsyncPath(file).write_text(file_contents)
 

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ def create_extension(*, language_name: str) -> Extension:
         else [
             "/std:c11",
             "/wd4244",
-            "/utf-8",      # Force UTF-8 encoding for source files
-            "/wd4819",     # Suppress warnings about source files with encoding issues
-            "/wd4566",     # Suppress warnings about character representation
+            "/utf-8",  # Force UTF-8 encoding for source files
+            "/wd4819",  # Suppress warnings about source files with encoding issues
+            "/wd4566",  # Suppress warnings about character representation
         ]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ def create_extension(*, language_name: str) -> Extension:
         else [
             "/std:c11",
             "/wd4244",
+            "/utf-8",      # Force UTF-8 encoding for source files
+            "/wd4819",     # Suppress warnings about source files with encoding issues
+            "/wd4566",     # Suppress warnings about character representation
         ]
     )
 


### PR DESCRIPTION
This PR addresses several issues that prevented proper installation and operation on Windows systems, particularly for users with non-English locales:

Fixed path handling in regex patterns to support both forward and backslash path separators
Added Windows-specific command execution for tree-sitter CLI through cmd.exe
Implemented proper handling of include paths in C source files on Windows
Most importantly, added critical MSVC compiler options to resolve encoding issue:

/utf-8 to force UTF-8 encoding for source files regardless of system locale

These changes ensure the package can be successfully built and installed on Windows systems using non-UTF8 code pages (CP949, CP932, etc.).

Fixes #14 