### PR TITLE
test: add reproduction case for Windows DLL loading issues with non-English locales

### DIFF
--- a/tests/test_windows_compatibility.py
+++ b/tests/test_windows_compatibility.py
@@ -1,0 +1,24 @@
+import unittest
+import platform
+
+class TestWindowsCompatibility(unittest.TestCase):
+    @unittest.skipIf(platform.system() != "Windows", "Windows specific test")
+    def test_import_languages_on_windows(self):
+        """Test that languages can be imported correctly on Windows."""
+        import tree_sitter_language_pack
+           
+        # Essayer de charger quelques langages courants
+        languages_to_test = ['python', 'javascript', 'typescript', 'java']
+           
+        for lang in languages_to_test:
+           try:
+               language = tree_sitter_language_pack.get_language(lang)
+               self.assertIsNotNone(language, f"The language {lang} could not be loaded")
+               
+               parser = tree_sitter_language_pack.get_parser(lang)
+               self.assertIsNotNone(parser, f"The parser for {lang} could not be created")
+           except Exception as e:
+               self.fail(f"Error loading language {lang}: {str(e)}")
+
+if __name__ == "__main__":
+   unittest.main()


### PR DESCRIPTION
This PR adds a unit test that reproduces the DLL loading issue on Windows with a non-English locale (French in my case). All languages fail with the error "DLL load failed while importing [language]: Le module spécifié est introuvable".
References issue #16 