### PR TITLE
fix: windows compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: "3.13"
+        python-version: ["3.13"]
         include:
           - os: windows-latest
             python-version: "3.12"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,10 +91,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.13"]
-        include:
-          - os: windows-latest
-            python-version: "3.12"
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -110,10 +106,10 @@ jobs:
       with:
         enable-cache: true
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version-file: "pyproject.toml"
 
     - name: Install Dependencies
       run: uv sync --no-install-project
@@ -122,27 +118,13 @@ jobs:
       run: echo "PROJECT_ROOT=${{ github.workspace }}" >> $GITHUB_ENV
       shell: bash
 
-    - name: Cache Bindings
-      id: cache-bindings
-      uses: actions/cache@v4
-      with:
-        path: tree_sitter_language_pack/bindings
-        key: ${{ runner.os }}-bindings-py${{ matrix.python-version }}-${{ hashFiles('sources/**/*', 'parsers/**/*.c', 'parsers/**/*.h') }}
-
-    - name: Build Extensions
-      if: steps.cache-bindings.outputs.cache-hit != 'true'
-      run: uv run --no-sync setup.py build_ext --inplace
-      env:
-        PROJECT_ROOT: ${{github.workspace}}
-
     - name: Cache Build
       id: cache-build
       uses: actions/cache@v4
       with:
         path: |
-          build
           dist
-        key: ${{ runner.os }}-build-py${{ matrix.python-version }}-${{ hashFiles('sources/**/*', 'parsers/**/*.c', 'parsers/**/*.h', 'setup.py') }}
+        key: ${{ runner.os }}-build-${{ hashFiles('sources/**/*', 'parsers/**/*', 'setup.py') }}
 
     - name: Build wheel
       if: steps.cache-build.outputs.cache-hit != 'true'
@@ -153,7 +135,7 @@ jobs:
     - name: Upload wheel artifact
       uses: actions/upload-artifact@v4
       with:
-        name: wheel-${{ matrix.os }}-py${{ matrix.python-version }}
+        name: wheel-${{ matrix.os }}
         path: dist/*.whl
         if-no-files-found: error
 
@@ -175,19 +157,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Set wheel Python version
-      run: |
-        if [[ "${{ matrix.os }}" == "windows-latest" && "${{ matrix.python-version }}" != "3.13" ]]; then
-          echo "WHEEL_PYTHON_VERSION=3.12" >> $GITHUB_ENV
-        else
-          echo "WHEEL_PYTHON_VERSION=3.13" >> $GITHUB_ENV
-        fi
-      shell: bash
-
     - name: Download wheel artifact
       uses: actions/download-artifact@v4
       with:
-        name: wheel-${{ matrix.os }}-py${{ env.WHEEL_PYTHON_VERSION }}
+        name: wheel-${{ matrix.os }}
         path: dist
 
     - name: Install wheel

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,10 @@ jobs:
       with:
         enable-cache: true
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version-file: "pyproject.toml"
 
     - name: Install Dependencies
       run: uv sync --no-install-project
@@ -110,10 +110,10 @@ jobs:
       with:
         enable-cache: true
 
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version-file: "pyproject.toml"
+        python-version: ${{ matrix.python-version }}
 
     - name: Install Dependencies
       run: uv sync --no-install-project
@@ -127,7 +127,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: tree_sitter_language_pack/bindings
-        key: ${{ runner.os }}-bindings-${{ hashFiles('sources/**/*', 'parsers/**/*.c', 'parsers/**/*.h') }}
+        key: ${{ runner.os }}-bindings-py${{ matrix.python-version }}-${{ hashFiles('sources/**/*', 'parsers/**/*.c', 'parsers/**/*.h') }}
 
     - name: Build Extensions
       if: steps.cache-bindings.outputs.cache-hit != 'true'
@@ -142,7 +142,7 @@ jobs:
         path: |
           build
           dist
-        key: ${{ runner.os }}-build-${{ hashFiles('sources/**/*', 'parsers/**/*.c', 'parsers/**/*.h', 'setup.py') }}
+        key: ${{ runner.os }}-build-py${{ matrix.python-version }}-${{ hashFiles('sources/**/*', 'parsers/**/*.c', 'parsers/**/*.h', 'setup.py') }}
 
     - name: Build wheel
       if: steps.cache-build.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,10 @@ jobs:
       with:
         enable-cache: true
 
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version-file: "pyproject.toml"
+        python-version: ${{ matrix.python-version }}
 
     - name: Install Dependencies
       run: uv sync --no-install-project
@@ -91,6 +91,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: "3.13"
+        include:
+          - os: windows-latest
+            python-version: "3.12"
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -149,7 +153,7 @@ jobs:
     - name: Upload wheel artifact
       uses: actions/upload-artifact@v4
       with:
-        name: wheel-${{ matrix.os }}
+        name: wheel-${{ matrix.os }}-py${{ matrix.python-version }}
         path: dist/*.whl
         if-no-files-found: error
 
@@ -171,10 +175,19 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Set wheel Python version
+      run: |
+        if [[ "${{ matrix.os }}" == "windows-latest" && "${{ matrix.python-version }}" != "3.13" ]]; then
+          echo "WHEEL_PYTHON_VERSION=3.12" >> $GITHUB_ENV
+        else
+          echo "WHEEL_PYTHON_VERSION=3.13" >> $GITHUB_ENV
+        fi
+      shell: bash
+
     - name: Download wheel artifact
       uses: actions/download-artifact@v4
       with:
-        name: wheel-${{ matrix.os }}
+        name: wheel-${{ matrix.os }}-py${{ env.WHEEL_PYTHON_VERSION }}
         path: dist
 
     - name: Install wheel

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
     - main
+    - fix/*
 
 jobs:
   clone_vendors:
@@ -81,7 +82,9 @@ jobs:
 
     - name: Run Linters
       run: uv run --no-sync pre-commit run --show-diff-on-failure --color=always --all-files
-  test:
+
+  build-wheel:
+    name: Build wheel
     needs: clone_vendors
     runs-on: ${{ matrix.os }}
     strategy:
@@ -111,18 +114,87 @@ jobs:
     - name: Install Dependencies
       run: uv sync --no-install-project
 
+    - name: Set path in environment
+      run: echo "PROJECT_ROOT=${{ github.workspace }}" >> $GITHUB_ENV
+      shell: bash
+
     - name: Cache Bindings
       id: cache-bindings
       uses: actions/cache@v4
       with:
         path: tree_sitter_language_pack/bindings
-        key: ${{ hashFiles('sources/*') }}-language-definitions
+        key: ${{ runner.os }}-bindings-${{ hashFiles('sources/**/*', 'parsers/**/*.c', 'parsers/**/*.h') }}
 
     - name: Build Extensions
       if: steps.cache-bindings.outputs.cache-hit != 'true'
       run: uv run --no-sync setup.py build_ext --inplace
-
-    - name: Test
-      run: uv run --no-sync pytest tests -v
       env:
         PROJECT_ROOT: ${{github.workspace}}
+
+    - name: Cache Build
+      id: cache-build
+      uses: actions/cache@v4
+      with:
+        path: |
+          build
+          dist
+        key: ${{ runner.os }}-build-${{ hashFiles('sources/**/*', 'parsers/**/*.c', 'parsers/**/*.h', 'setup.py') }}
+
+    - name: Build wheel
+      if: steps.cache-build.outputs.cache-hit != 'true'
+      run: uv build --wheel
+      env:
+        PROJECT_ROOT: ${{github.workspace}}
+
+    - name: Upload wheel artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheel-${{ matrix.os }}
+        path: dist/*.whl
+        if-no-files-found: error
+
+  test-wheel:
+    name: Test wheel
+    needs: build-wheel
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Download wheel artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: wheel-${{ matrix.os }}
+        path: dist
+
+    - name: Install wheel
+      shell: bash
+      run: |
+        wheel_file=$(ls dist/*.whl 2>/dev/null | head -n 1)
+        if [ -z "$wheel_file" ]; then
+          wheel_file=$(find dist -name "*.whl" -type f | head -n 1)
+        fi
+        echo "Installing wheel: $wheel_file"
+        pip install "$wheel_file"
+
+    - name: Install pytest
+      run: pip install pytest
+
+    - name: Test with installed wheel
+      run: |
+        mkdir -p /tmp/test_wheel
+        cp tests/entry_point_test.py /tmp/test_wheel/
+        cd /tmp/test_wheel
+        pytest entry_point_test.py -v
+      env:
+        PROJECT_ROOT: ${{ github.workspace }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
   "pytest>=8.3.4",
   "ruff>=0.9.9",
   "setuptools>=75.8.2",
+  "tomli>=2.2.1; python_version<'3.11'",
   "types-setuptools>=75.8.2.20250301",
   "typing-extensions>=4.12.2",
 ]

--- a/scripts/update_dependencies.py
+++ b/scripts/update_dependencies.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import re
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
-import tomllib  # type: ignore[import-not-found]
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[import-not-found]
 
 
 def uv(subcommand: str, packages: list[str], group: str | None) -> None:

--- a/scripts/update_dependencies.py
+++ b/scripts/update_dependencies.py
@@ -5,7 +5,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-import tomllib  # type: ignore[import-untyped]
+import tomllib  # type: ignore[import-not-found]
 
 
 def uv(subcommand: str, packages: list[str], group: str | None) -> None:

--- a/setup.py
+++ b/setup.py
@@ -40,14 +40,19 @@ def create_extension(*, language_name: str) -> Extension:
         ]
     )
 
+    define_macros = [
+        ("PY_SSIZE_T_CLEAN", None),
+        ("TREE_SITTER_HIDE_SYMBOLS", None),
+        ("TS_LANGUAGE_NAME", language_name),
+    ]
+
+    if system() == "Windows":
+        define_macros.append(("Py_LIMITED_API", str(0x03090000)))  # Python 3.9+
+
     return Extension(
         name=f"tree_sitter_language_pack.bindings.{language_name}",
         py_limited_api=True,
-        define_macros=[
-            ("PY_SSIZE_T_CLEAN", None),
-            ("TREE_SITTER_HIDE_SYMBOLS", None),
-            ("TS_LANGUAGE_NAME", language_name),
-        ],
+        define_macros=define_macros,
         extra_compile_args=compile_args,
         sources=[],
     )
@@ -101,6 +106,10 @@ class BdistWheel(bdist_wheel):
             # Support all Python versions >= 3.9 using abi3
             return "cp39", "abi3", platform
         return python, abi, platform
+
+    def finalize_options(self) -> None:
+        """Finalize options for wheel building."""
+        self.py_limited_api = f"cp{MIN_PYTHON_VERSION}"
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def create_extension(*, language_name: str) -> Extension:
     ]
 
     if system() == "Windows":
-        define_macros.append(("Py_LIMITED_API", str(0x03090000)))  # Python 3.9+
+        define_macros.append(("Py_LIMITED_API", "0x03090000"))  # Python 3.9+
 
     return Extension(
         name=f"tree_sitter_language_pack.bindings.{language_name}",
@@ -106,10 +106,6 @@ class BdistWheel(bdist_wheel):
             # Support all Python versions >= 3.9 using abi3
             return "cp39", "abi3", platform
         return python, abi, platform
-
-    def finalize_options(self) -> None:
-        """Finalize options for wheel building."""
-        self.py_limited_api = f"cp{MIN_PYTHON_VERSION}"
 
 
 setup(

--- a/tests/entry_point_test.py
+++ b/tests/entry_point_test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 from json import loads
 from pathlib import Path
@@ -26,8 +25,7 @@ def load_language_definitions() -> dict[str, dict[str, str]]:
         if path.exists():
             return cast(dict[str, dict[str, str]], loads(path.read_text()))
 
-raise AssertionError("language_definitions.json not found, using SupportedLanguage directly")
-    return {lang: {} for lang in SupportedLanguage.__args__}  # type: ignore[attr-defined]
+    raise AssertionError("language_definitions.json not found, using SupportedLanguage directly")
 
 
 language_definitions = load_language_definitions()

--- a/tests/entry_point_test.py
+++ b/tests/entry_point_test.py
@@ -26,7 +26,7 @@ def load_language_definitions() -> dict[str, dict[str, str]]:
         if path.exists():
             return cast(dict[str, dict[str, str]], loads(path.read_text()))
 
-    logging.warning("language_definitions.json not found, using SupportedLanguage directly")
+raise AssertionError("language_definitions.json not found, using SupportedLanguage directly")
     return {lang: {} for lang in SupportedLanguage.__args__}  # type: ignore[attr-defined]
 
 

--- a/tree_sitter_language_pack/__init__.py
+++ b/tree_sitter_language_pack/__init__.py
@@ -198,6 +198,9 @@ def get_binding(language_name: SupportedLanguage) -> object:
         module = import_module(name=f".bindings.{language_name}", package=__package__)
         return cast(object, module.language())
     except (ModuleNotFoundError, ImportError) as e:
+        # Workaround for Windows environments where wheels built with one Python version (e.g., 3.12)
+        # and installed on a different version (e.g., 3.9) fail with "DLL load failed while importing".
+        # This may be a Python bug, handling cases where the normal import_module mechanism fails.
         package_path = Path(__file__).parent
         ext = ".pyd" if sys.platform.startswith("win") else ".so"
         lib_path = package_path / "bindings" / f"{language_name}{ext}"

--- a/tree_sitter_language_pack/__init__.py
+++ b/tree_sitter_language_pack/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import ctypes
+import sys
 from importlib import import_module
+from pathlib import Path
 from typing import Literal, cast
 
 import tree_sitter_c_sharp
@@ -194,8 +197,23 @@ def get_binding(language_name: SupportedLanguage) -> object:
     try:
         module = import_module(name=f".bindings.{language_name}", package=__package__)
         return cast(object, module.language())
-    except ModuleNotFoundError as e:
-        raise LookupError(f"Language not found: {language_name}") from e
+    except (ModuleNotFoundError, ImportError) as e:
+        package_path = Path(__file__).parent
+
+        ext = ".pyd" if sys.platform.startswith("win") else ".so"
+
+        possible_paths = [
+            package_path / "bindings" / f"{language_name}{ext}",
+        ]
+
+        lib_path = next((p for p in possible_paths if p.exists()), None)
+
+        if lib_path is None:
+            raise LookupError(f"Could not find language library for {language_name}") from e
+
+        lib = ctypes.cdll.LoadLibrary(str(lib_path))
+        language_fn = getattr(lib, f"tree_sitter_{language_name}")
+        return language_fn()
 
 
 def get_language(language_name: SupportedLanguage) -> Language:

--- a/uv.lock
+++ b/uv.lock
@@ -611,7 +611,7 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-language-pack"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "tree-sitter", version = "0.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },

--- a/uv.lock
+++ b/uv.lock
@@ -634,6 +634,7 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "setuptools" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "types-setuptools" },
     { name = "typing-extensions" },
 ]
@@ -656,6 +657,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.9.9" },
     { name = "setuptools", specifier = ">=75.8.2" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.2.1" },
     { name = "types-setuptools", specifier = ">=75.8.2.20250301" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]


### PR DESCRIPTION
Fix Windows wheel compatibility across Python versions

- Adding a ctypes-based fallback mechanism in `get_binding()` to directly load .pyd files when module import fails
- Explicitly defining `Py_LIMITED_API` macro for Windows builds to ensure proper abi3 compatibility
- Updates the CI test matrix to cover multiple python versions (3.9-3.13)
- Modifies tests to build wheels first, then install and test those wheels instead of testing the source directly

I hope this resolves the issues in the Windows environment.

#16