### PR TITLE
fix: fix MSYS2 GCC build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,7 @@ jobs:
       with:
         path: |
           dist
+          *.whl
         key: ${{ matrix.os }}-build-${{ hashFiles('sources/**/*', 'parsers/**/*', 'setup.py') }}
 
     - name: Build wheel
@@ -132,11 +133,28 @@ jobs:
       env:
         PROJECT_ROOT: ${{github.workspace}}
 
-    - name: Upload wheel artifact
+    - name: Setup MSYS2 GCC build
+      if: matrix.os == 'windows-latest'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: true
+        pacboy: python-pip:p gcc:p
+
+    - name: Build MSYS2 GCC wheel
+      if: matrix.os == 'windows-latest' && steps.cache-build.outputs.cache-hit != 'true'
+      shell: msys2 {0}
+      run: |
+        . .venv/Scripts/activate
+        pip wheel --no-deps .
+
+    - name: Upload wheel artifacts
       uses: actions/upload-artifact@v4
       with:
         name: wheel-${{ matrix.os }}
-        path: dist/*.whl
+        path: |
+          dist/*.whl
+          *.whl
         if-no-files-found: error
 
   test-wheel:
@@ -157,11 +175,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Download wheel artifact
+    - name: Download wheel artifacts
       uses: actions/download-artifact@v4
       with:
         name: wheel-${{ matrix.os }}
-        path: dist
 
     - name: Install wheel
       shell: bash
@@ -177,6 +194,41 @@ jobs:
       run: pip install pytest
 
     - name: Test with installed wheel
+      run: |
+        mkdir -p /tmp/test_wheel
+        cp tests/entry_point_test.py /tmp/test_wheel/
+        cd /tmp/test_wheel
+        pytest entry_point_test.py -v
+      env:
+        PROJECT_ROOT: ${{ github.workspace }}
+
+    - name: Set up MSYS2 Python
+      if: matrix.os == 'windows-latest'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: true
+        pacboy: python-pip:p gcc:p
+
+    - name: Install MSYS2 GCC wheel
+      if: matrix.os == 'windows-latest'
+      shell: msys2 {0}
+      run: |
+        wheel_file=$(ls *.whl 2>/dev/null | head -n 1)
+        if [ -z "$wheel_file" ]; then
+          wheel_file=$(find . -name "*.whl" -type f | head -n 1)
+        fi
+        echo "Installing wheel: $wheel_file"
+        pip install "$wheel_file"
+
+    - name: Install MSYS2 pytest
+      if: matrix.os == 'windows-latest'
+      shell: msys2 {0}
+      run: pip install pytest
+
+    - name: Test with installed MSYS2 wheel
+      if: matrix.os == 'windows-latest'
+      shell: msys2 {0}
       run: |
         mkdir -p /tmp/test_wheel
         cp tests/entry_point_test.py /tmp/test_wheel/

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def create_extension(*, language_name: str) -> Extension:
             "-fvisibility=hidden",
             "-std=c11",
         ]
-        if system() != "Windows"
+        if system() != "Windows" or "MSYSTEM" in environ
         else [
             "/std:c11",
             "/utf-8",


### PR DESCRIPTION
Fixes building on MSYS2 using GCC, where `system()` outputs `Windows`, which was misused in `setup.py`, causing invalid flags to be passed to GCC.

Depends on:

- tree-sitter/py-tree-sitter#340
- tree-sitter/tree-sitter-c-sharp#374
- tree-sitter/tree-sitter-embedded-template#35
- tree-sitter-grammars/tree-sitter-yaml#22.