### PR TITLE
Include 'markdown_inline' parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Each language below is identified by the key used to retrieve it from the `get_l
 - [magik](https://github.com/krn-robin/tree-sitter-magik) - MIT License
 - [make](https://github.com/tree-sitter-grammars/tree-sitter-make) - MIT License
 - [markdown](https://github.com/tree-sitter-grammars/tree-sitter-markdown) - MIT License
+- [markdown_inline](https://github.com/tree-sitter-grammars/tree-sitter-markdown) - MIT License
 - [matlab](https://github.com/acristoffers/tree-sitter-matlab) - MIT License
 - [mermaid](https://github.com/monaqa/tree-sitter-mermaid) - MIT License
 - [meson](https://github.com/tree-sitter-grammars/tree-sitter-meson) - MIT License

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -115,7 +115,8 @@
     "repo": "https://github.com/elixir-lang/tree-sitter-elixir"
   },
   "elm": {
-    "repo": "https://github.com/razzeee/tree-sitter-elm"
+    "repo": "https://github.com/razzeee/tree-sitter-elm",
+    "rev": "c26afd7f2316f689410a1622f1780eff054994b1"
   },
   "erlang": {
     "repo": "https://github.com/WhatsApp/tree-sitter-erlang"
@@ -415,8 +416,8 @@
     "repo": "https://github.com/tree-sitter/tree-sitter-ruby"
   },
   "rust": {
-    "branch": "master",
-    "repo": "https://github.com/tree-sitter/tree-sitter-rust"
+    "repo": "https://github.com/tree-sitter/tree-sitter-rust",
+    "rev": "3d087c3df25286140393ddecc339208fae107149"
   },
   "scala": {
     "branch": "master",

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -284,6 +284,11 @@
     "directory": "tree-sitter-markdown",
     "repo": "https://github.com/tree-sitter-grammars/tree-sitter-markdown"
   },
+  "markdown_inline": {
+    "branch": "split_parser",
+    "directory": "tree-sitter-markdown-inline",
+    "repo": "https://github.com/tree-sitter-grammars/tree-sitter-markdown"
+  },
   "matlab": {
     "repo": "https://github.com/acristoffers/tree-sitter-matlab"
   },

--- a/tree_sitter_language_pack/__init__.py
+++ b/tree_sitter_language_pack/__init__.py
@@ -94,6 +94,7 @@ SupportedLanguage = Literal[
     "luau",
     "make",
     "markdown",
+    "markdown_inline",
     "matlab",
     "mermaid",
     "meson",

--- a/uv.lock
+++ b/uv.lock
@@ -634,7 +634,7 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "setuptools" },
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "types-setuptools" },
     { name = "typing-extensions" },
 ]
@@ -657,7 +657,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.0" },
     { name = "setuptools", specifier = ">=76.0.0" },
-    { name = "tomli", specifier = ">=2.2.1" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.2.1" },
     { name = "types-setuptools", specifier = ">=76.0.0.20250313" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]


### PR DESCRIPTION
This PR allows the use of the inline variant of the markdown grammar/parser.

The non-inline version will fail with the query:

```
>>> parser = tree_sitter_language_pack.get_parser("markdown")
>>> parser.language.query("(image (image_description) @alt (link_destination) @url)")
---------------------------------------------------------------------------
QueryError                                Traceback (most recent call last)
Cell In[8], line 1
----> 1 parser.language.query("(image (image_description) @alt (link_destination) @url)")
```

But the inline version works:

```
>>> parser = tree_sitter_language_pack.get_parser("markdown_inline")
>>> query = parser.language.query("(image (image_description) @alt (link_destination) @url)")

>>> tree = parser.parse(b"""
... ![A table made of trees](markdown-images-treesitter.png)
... ![A table made of trees](markdown-images-treesitter.png)
...
... Nothing.
... """)

>>> query.captures(tree.root_node)
>>> query.captures(tree.root_node)
{'alt': [<Node type=image_description, start_point=(1, 2), end_point=(1, 23)>,
  <Node type=image_description, start_point=(2, 2), end_point=(2, 23)>],
 'url': [<Node type=link_destination, start_point=(1, 25), end_point=(1, 55)>,
  <Node type=link_destination, start_point=(2, 25), end_point=(2, 55)>]}

```


