### PR TITLE
Pin vendored `tree-sitter-tcl` to known-good revision

### DIFF
--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -475,7 +475,8 @@
     "repo": "https://github.com/Flakebi/tree-sitter-tablegen"
   },
   "tcl": {
-    "repo": "https://github.com/lewis6991/tree-sitter-tcl"
+    "repo": "https://github.com/lewis6991/tree-sitter-tcl",
+    "rev": "ce03bbd6bb74f902adfaa37a294c34cbe05ef940"
   },
   "terraform": {
     "directory": "dialects/terraform",


### PR DESCRIPTION
Upstream commit https://github.com/tree-sitter-grammars/tree-sitter-tcl/commit/802deaff8e127ee20f1d5f9e58ab959003f24b92 switched to [language version 15](https://github.com/tree-sitter-grammars/tree-sitter-tcl/blob/802deaff8e127ee20f1d5f9e58ab959003f24b92/src/parser.c#L9), which is incompatible with the version that tree-sitter-language-pack expects.

This causes the TCL integration to fail. Here’s a small self-contained reproducer:

```py
from tree_sitter import Language, Parser
import tree_sitter_language_pack.bindings.tcl as binding
capsule = binding.language()
language = Language(capsule)
Parser(language)                # <== causes a ValueError
```

The reproducer results in the following error:

> ValueError: Incompatible Language version 15. Must be between 13 and 14

The following unit test fails with the same error:

```py
pytest -k 'test_get_parser[tcl]' --import-mode=append tests
```

This PR pins `tree-sitter-tcl` to the last known-good upstream commit.

See also related PR #30 by @yzx9 and PR #27.
