### PR TITLE
Bump swift (for macros + copyable)

### DIFF
--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -606,7 +606,7 @@
   "swift": {
     "generate": true,
     "repo": "https://github.com/alex-pinkus/tree-sitter-swift",
-    "rev": "aca5a52aa3cab858944d3c02701ccf5b2d8fd0f9"
+    "rev": "f67f569270ce8664a065313f1086a3484a3bec77"
   },
   "tablegen": {
     "branch": "master",


### PR DESCRIPTION
Bump swift to its latest commit to get these two improvements:
- https://github.com/alex-pinkus/tree-sitter-swift/issues/438
- https://github.com/alex-pinkus/tree-sitter-swift/pull/479