### PR TITLE
feat: add netlinx language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Each language below is identified by the key used to retrieve it from the `get_l
 - [matlab](https://github.com/acristoffers/tree-sitter-matlab) - MIT License
 - [mermaid](https://github.com/monaqa/tree-sitter-mermaid) - MIT License
 - [meson](https://github.com/tree-sitter-grammars/tree-sitter-meson) - MIT License
+- [netlinx](https://github.com/Norgate-AV/tree-sitter-netlinx) - MIT License
 - [ninja](https://github.com/alemuller/tree-sitter-ninja) - MIT License
 - [nix](https://github.com/nix-community/tree-sitter-nix) - MIT License
 - [nqc](https://github.com/tree-sitter-grammars/tree-sitter-nqc) - MIT License

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -391,6 +391,10 @@
     "repo": "https://github.com/Decodetalkers/tree-sitter-meson",
     "rev": "e39eeb2b1d8bcedb85c1a7f83ac6de6012a5f22b"
   },
+  "netlinx": {
+    "repo": "https://github.com/Norgate-AV/tree-sitter-netlinx",
+    "rev": "6d3c01e54d150c6d3dcf99cad95a1f5fa0293018"
+  },
   "ninja": {
     "repo": "https://github.com/alemuller/tree-sitter-ninja",
     "rev": "0a95cfdc0745b6ae82f60d3a339b37f19b7b9267"

--- a/tree_sitter_language_pack/__init__.py
+++ b/tree_sitter_language_pack/__init__.py
@@ -99,6 +99,7 @@ SupportedLanguage = Literal[
     "matlab",
     "mermaid",
     "meson",
+    "netlinx",
     "ninja",
     "nix",
     "nqc",


### PR DESCRIPTION
Add supports for the [NetLinx](https://pldb.io/concepts/netlinx.html) language via [Norgate-AV/tree-sitter-netlinx](https://github.com/Norgate-AV/tree-sitter-netlinx).

License is MIT.

I've (hopefully) followed preferred approach for the contribution as per notes in the README and feedback I can see on past PRs. There is a [PyPi package available](https://pypi.org/project/tree-sitter-netlinx/) which could be added to `pyproject.toml` and imported, but that appears to be the exception rather than the norm. Please do let me know if you'd prefer that to be switched.

I'm not the original author of the grammar, but I am using it in [other tooling](https://git.sr.ht/~kb/netlinx.nvim) and can vouch for accuracy in the pinned version. It would be great to make use of this in [Aider](https://aider.chat) - tracing dependencies leads here as the spot to make that happen.

Thanks for the time/effort maintaining everything here to give upstream tools something to lean on.