### PR TITLE
add Graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Each language below is identified by the key used to retrieve it from the `get_l
 - [go](https://github.com/tree-sitter/tree-sitter-go) - MIT License
 - [gomod](https://github.com/camdencheek/tree-sitter-go-mod) - MIT License
 - [gosum](https://github.com/tree-sitter-grammars/tree-sitter-go-sum) - MIT License
+- [graphql](https://github.com/bkegley/tree-sitter-graphql0) - MIT License
 - [groovy](https://github.com/Decodetalkers/tree-sitter-groovy) - MIT License
 - [gstlaunch](https://github.com/tree-sitter-grammars/tree-sitter-gstlaunch) - MIT License
 - [hack](https://github.com/slackhq/tree-sitter-hack) - MIT License

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Each language below is identified by the key used to retrieve it from the `get_l
 - [go](https://github.com/tree-sitter/tree-sitter-go) - MIT License
 - [gomod](https://github.com/camdencheek/tree-sitter-go-mod) - MIT License
 - [gosum](https://github.com/tree-sitter-grammars/tree-sitter-go-sum) - MIT License
-- [graphql](https://github.com/bkegley/tree-sitter-graphql0) - MIT License
+- [graphql](https://github.com/bkegley/tree-sitter-graphql) - MIT License
 - [groovy](https://github.com/Decodetalkers/tree-sitter-groovy) - MIT License
 - [gstlaunch](https://github.com/tree-sitter-grammars/tree-sitter-gstlaunch) - MIT License
 - [hack](https://github.com/slackhq/tree-sitter-hack) - MIT License

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -227,6 +227,10 @@
     "repo": "https://github.com/tree-sitter-grammars/tree-sitter-go-sum",
     "rev": "e2ac513b2240c7ff1069ae33b2df29ce90777c11"
   },
+  "graphql": {
+    "repo": "https://github.com/bkegley/tree-sitter-graphql",
+    "rev": "5e66e961eee421786bdda8495ed1db045e06b5fe"
+  },
   "groovy": {
     "branch": "gh-pages",
     "repo": "https://github.com/Decodetalkers/tree-sitter-groovy",

--- a/tree_sitter_language_pack/__init__.py
+++ b/tree_sitter_language_pack/__init__.py
@@ -64,6 +64,7 @@ SupportedLanguage = Literal[
     "go",
     "gomod",
     "gosum",
+    "graphql",
     "groovy",
     "gstlaunch",
     "hack",


### PR DESCRIPTION
Add supports for the graphql language via [bkegley/tree-sitter-graphql](https://github.com/bkegley/tree-sitter-graphql)

License is MIT.