### PR TITLE
feat: add WASM WAT and WAST format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Each language below is identified by the key used to retrieve it from the `get_l
 - [vhdl](https://github.com/alemuller/tree-sitter-vhdl) - MIT License
 - [vim](https://github.com/tree-sitter-grammars/tree-sitter-vim) - MIT License
 - [vue](https://github.com/tree-sitter-grammars/tree-sitter-vue) - MIT License
+- [wast & wat](https://github.com/mkatychev/tree-sitter-wasm) - Apache License 2.0 WITH LLVM-exception
 - [wgsl](https://github.com/szebniok/tree-sitter-wgsl) - MIT License
 - [xcompose](https://github.com/tree-sitter-grammars/tree-sitter-xcompose) - MIT License
 - [xml](https://github.com/tree-sitter-grammars/tree-sitter-xml) - MIT License

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Each language below is identified by the key used to retrieve it from the `get_l
 - [vhdl](https://github.com/alemuller/tree-sitter-vhdl) - MIT License
 - [vim](https://github.com/tree-sitter-grammars/tree-sitter-vim) - MIT License
 - [vue](https://github.com/tree-sitter-grammars/tree-sitter-vue) - MIT License
-- [wast & wat](https://github.com/mkatychev/tree-sitter-wasm) - Apache License 2.0 WITH LLVM-exception
+- [wast & wat](https://github.com/mkatychev/tree-sitter-wasm) - Apache License 2.0 with LLVM-exception
 - [wgsl](https://github.com/szebniok/tree-sitter-wgsl) - MIT License
 - [xcompose](https://github.com/tree-sitter-grammars/tree-sitter-xcompose) - MIT License
 - [xml](https://github.com/tree-sitter-grammars/tree-sitter-xml) - MIT License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ lint.per-file-ignores."tests/**/*.*" = [ "D", "S" ]
 lint.isort.known-first-party = [ "tree_sitter_language_pack", "tests" ]
 lint.pydocstyle.convention = "google"
 
+[tool.codespell]
+ignore-words-list = "wast"
+
 [tool.pyproject-fmt]
 keep_full_version = true
 max_supported_python = "3.13"

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -728,6 +728,16 @@
     "repo": "https://github.com/tree-sitter-grammars/tree-sitter-vue",
     "rev": "7e48557b903a9db9c38cea3b7839ef7e1f36c693"
   },
+  "wast": {
+    "repo": "https://github.com/mkatychev/tree-sitter-wasm",
+    "rev": "2357ad78eed2d703071f737b2ece1ae7ea49bf42",
+    "directory": "wast"
+  },
+  "watt": {
+    "repo": "https://github.com/mkatychev/tree-sitter-wasm",
+    "rev": "2357ad78eed2d703071f737b2ece1ae7ea49bf42",
+    "directory": "wat"
+  },
   "wgsl": {
     "branch": "master",
     "repo": "https://github.com/szebniok/tree-sitter-wgsl",

--- a/sources/language_definitions.json
+++ b/sources/language_definitions.json
@@ -733,7 +733,7 @@
     "rev": "2357ad78eed2d703071f737b2ece1ae7ea49bf42",
     "directory": "wast"
   },
-  "watt": {
+  "wat": {
     "repo": "https://github.com/mkatychev/tree-sitter-wasm",
     "rev": "2357ad78eed2d703071f737b2ece1ae7ea49bf42",
     "directory": "wat"

--- a/tree_sitter_language_pack/__init__.py
+++ b/tree_sitter_language_pack/__init__.py
@@ -174,6 +174,8 @@ SupportedLanguage = Literal[
     "vhdl",
     "vim",
     "vue",
+    "wast",
+    "wat",
     "wgsl",
     "xcompose",
     "xml",

--- a/uv.lock
+++ b/uv.lock
@@ -528,7 +528,7 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-language-pack"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "tree-sitter", version = "0.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
This pull request adds support for the WebAssembly text languages `wast` and `wat` to the project. The changes include updating documentation, configuration, and source definitions to recognize and properly handle these languages.

**Support for new languages:**

* Added `wast` and `wat` to the list of supported languages in `tree_sitter_language_pack/__init__.py` and updated `sources/language_definitions.json` with their repository and directory information. [[1]](diffhunk://#diff-9df48dff8c405117c7625f6b7cec55750e3d16f79543270d7a13faa8ca8f19caR177-R178) [[2]](diffhunk://#diff-e876f0953d9b3a1935bd47a3fa5b3fd407912d0e8c6d28d6098a383260745778R731-R740)

**Documentation updates:**

* Updated `README.md` to include `wast & wat` with licensing and repository details.

**Configuration improvements:**

* Updated `pyproject.toml` to add `wast` to the codespell ignore list to prevent false positives during spell checking.